### PR TITLE
[11.0][FIX] add attachments to holidays

### DIFF
--- a/cb_holidays_compute_mix/security/holidays_security.xml
+++ b/cb_holidays_compute_mix/security/holidays_security.xml
@@ -5,8 +5,11 @@
         <field name="name">Invisible</field>
     </record>
 
+    <record id="hr_holidays.property_rule_holidays_employee_write" model="ir.rule">
+        <field name="active" eval="False"/>
+    </record>
 
-    <data noupdate="0">
+    <data noupdate="1">
         <record id="hr_holidays.property_rule_holidays_officer" model="ir.rule">
                 <field name="active" eval="False"/>
         </record>

--- a/cb_hr_views/security/hr_employee_security.xml
+++ b/cb_hr_views/security/hr_employee_security.xml
@@ -50,4 +50,5 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+
 </odoo>


### PR DESCRIPTION
Esta rule hacía que no se pudieran editar los registros cuando están en estado validado/aceptado. Causaba que no se pudieran añadir adjuntos, lo cual va bien para que la gente añada justificantes. Esto no causa ningun problema ya que todos los campos son readonly igualmente.
Además deja a los usuarios devolver las ausencias rechazadas a borrador, que también va bien para que vuelvas a pedir vacaciones modificando ese mismo registro, sin la necesidad de crear otro.