### PR TITLE
[11.0][FIX] Remove meeting button from res.partner

### DIFF
--- a/cb_hr_views/__manifest__.py
+++ b/cb_hr_views/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "www.creublanca.es",
     "depends": [
         "base_fontawesome",
+        "crm",
         "hr_attendance",
         "hr_contract",
         "hr_family",

--- a/cb_hr_views/views/res_partner.xml
+++ b/cb_hr_views/views/res_partner.xml
@@ -38,4 +38,27 @@
             </xpath>
         </field>
     </record>
+
+    <record model="ir.ui.view" id="view_partners_form_crm1">
+        <field name="name">res.partner.form.crm (in cb_hr_views)</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="crm.view_partners_form_crm1"/>
+        <field name="arch" type="xml">
+            <button name="schedule_meeting" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </button>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="crm_lead_partner_kanban_view">
+        <field name="name">res.partner.kanban.crm (in cb_hr_views)</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="crm.crm_lead_partner_kanban_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//t[@t-esc='record.meeting_count.value']/.." position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Se quita el span lila que dice cuantos meetings tienes en el kaban y el smart button del res.partner. Los meetings no se estaban usando, simplemente eran generados por el holidays.