### PR TITLE
[12.0][FIX] cb_holidays_compute_mix: view fixes

### DIFF
--- a/cb_holidays_compute_mix/views/hr_leave_views.xml
+++ b/cb_holidays_compute_mix/views/hr_leave_views.xml
@@ -154,4 +154,33 @@
             </filter>
         </field>
     </record>
+    <record id="hr_leave_allocation_view_form" model="ir.ui.view">
+        <field name="name">Leave Allocation - Compute Mix</field>
+        <field name="model">hr.leave.allocation</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_allocation_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='accrual']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <field name="holiday_status_id" position="attributes">
+                <attribute name="domain">[("allocation_type", "!=", "no")]</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="hr_leave_allocation_view_form_manager" model="ir.ui.view">
+        <field name="name">Leave Allocation - Compute Mix</field>
+        <field name="model">hr.leave.allocation</field>
+        <field
+            name="inherit_id"
+            ref="hr_holidays.hr_leave_allocation_view_form_manager"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='holiday_status_id']" position="attributes">
+                <attribute name="domain">[("allocation_type", "!=", "no")]</attribute>
+            </xpath>
+            <xpath expr="//field[@name='accrual']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Arregla un domain innecesario, puesto que las ausencias pueden pedirse fuera del intervalo "permitido".

Se overridea `_compute_number_of_hours_display` para que `number_of_hours` sea 0 si tiene que ser 0, y no `number_of_days * HOURS_PER_DAY` como en odoo core. (https://github.com/odoo/odoo/blob/12.0/addons/hr_holidays/models/hr_leave.py#L417)

