### PR TITLE
[FIX] cb_hr_views: fix computation today_schedule

### DIFF
--- a/cb_departments_chart/tests/test_departments_chart.py
+++ b/cb_departments_chart/tests/test_departments_chart.py
@@ -4,7 +4,7 @@
 import json
 
 import mock
-from odoo.tests.common import HOST, PORT, HttpCase, TransactionCase
+from odoo.tests.common import HttpCase, TransactionCase
 
 
 class TestCBDepartmentsChart(TransactionCase):
@@ -51,12 +51,9 @@ class TestCBDepartmentsChartHttp(HttpCase):
     def test_departments_chart_controller(self, r):
         data = {"params": {"department_id": self.department_1.id}}
         url = "/cb_departments_chart/get_org_chart"
-        url = "http://{}:{}{}".format(HOST, PORT, url)
         headers = {"Content-Type": "application/json"}
         data = json.dumps(data)
-        response = self.opener.post(
-            url, data=data, headers=headers, timeout=10
-        )
+        response = self.url_open(url, data=data, headers=headers, timeout=10)
         json_data = json.loads(response.text)
         self.assertEqual(json_data["result"]["self"]["name"], "Dep1")
         self.assertEqual(json_data["result"]["self"]["direct_sub_count"], 1)
@@ -67,10 +64,7 @@ class TestCBDepartmentsChartHttp(HttpCase):
     def test_no_department_id(self, r):
         data = {"params": {"department_id": False}}
         url = "/cb_departments_chart/get_org_chart"
-        url = "http://{}:{}{}".format(HOST, PORT, url)
         headers = {"Content-Type": "application/json"}
         data = json.dumps(data)
-        response = self.opener.post(
-            url, data=data, headers=headers, timeout=10
-        )
+        response = self.url_open(url, data=data, headers=headers, timeout=10)
         json.loads(response.text)

--- a/cb_hr_views/models/hr_employee.py
+++ b/cb_hr_views/models/hr_employee.py
@@ -180,6 +180,7 @@ class HrEmployee(models.Model):
                 limit=1,
             )
 
+    @api.depends("resource_calendar_id")
     def _compute_today_schedule(self):
         public_holidays = self.env["hr.holidays.public"]
         today = fields.Date.today()


### PR DESCRIPTION
I cannot install it. Gives me the following error: 
File "/home/alba.riera/PycharmProjects/cb-hr/cb_departments_chart/tests/test_departments_chart.py", line 7, in <module>
    from odoo.tests.common import HOST, PORT, HttpCase, TransactionCase
          ImportError: cannot import name 'PORT' from 'odoo.tests.common' 
           (/home/alba.riera/PycharmProjects/odoo/odoo/tests/common.py) from ...




And after that starts again to install "base", etc...
