### PR TITLE
[16.0] [IMP] cb_hr_views: delete domain in parent_id field in hr.employee model

### DIFF
--- a/cb_hr_views/models/hr_employee.py
+++ b/cb_hr_views/models/hr_employee.py
@@ -45,9 +45,11 @@ class HrEmployee(models.Model):
     )
     work_email = fields.Char(related="partner_id.email", store=True)
     parent_id = fields.Many2one(
+        "hr.employee",
         compute="_compute_department_parent_id",
         groups="hr.group_hr_user",
         store=True,
+        domain=[],
     )
     company_id = fields.Many2one(
         compute="_compute_company",

--- a/cb_hr_views/tests/test_cb_hr_views.py
+++ b/cb_hr_views/tests/test_cb_hr_views.py
@@ -188,3 +188,8 @@ class TestCbHrViews(TransactionCase):
 
         self.assertEqual(self.employee.contract_id, self.contract)
         self.assertEqual(self.employee.company_id, company_2)
+
+    def test_get_manager_domain(self):
+        """The manager field allow show employees of all companies."""
+
+        self.assertEqual([], self.employee._fields["parent_id"].domain)


### PR DESCRIPTION
Allow search across employees of all companies