### PR TITLE
[16.0] [IMP] cb_hr_views: move logic to correct method

### DIFF
--- a/cb_hr_views/models/hr_employee.py
+++ b/cb_hr_views/models/hr_employee.py
@@ -227,12 +227,6 @@ class HrEmployee(models.Model):
             )
             record.user_id = user_id
 
-    @api.onchange("company_id")
-    def _onchange_company(self):
-        if not self.env.context.get("use_old_onchange"):
-            return super()._onchange_company()
-        return {}
-
     def _update_employee_manager(self, manager_id):
         return
 
@@ -293,7 +287,9 @@ class HrEmployeeBase(models.AbstractModel):
 
     @api.depends()
     def _compute_address_id(self):
-        res = super(
-            HrEmployeeBase, self.filtered(lambda r: not r.address_id)
-        )._compute_address_id()
-        return res
+        if not self.env.context.get("use_old_onchange"):
+            res = super(
+                HrEmployeeBase, self.filtered(lambda r: not r.address_id)
+            )._compute_address_id()
+            return res
+        return {}


### PR DESCRIPTION
With this we fix MR58120.

In the migration from 13.0 to 14.0, the logic was moved to computed method, I don't know if it will have the same effect but onchange disappears on 14 and compute was added.

By other side, I have doubts of the pass of the key "use_old_onchange", I'm not able to find anyware, can be obsolate?