### PR TITLE
[16.0] [IMP] cb_hr_views: avoid set default company in work locations

### DIFF
--- a/cb_hr_views/models/hr_employee.py
+++ b/cb_hr_views/models/hr_employee.py
@@ -297,3 +297,10 @@ class HrEmployeeBase(models.AbstractModel):
             HrEmployeeBase, self.filtered(lambda r: not r.address_id)
         )._compute_address_id()
         return res
+
+    @api.depends("address_id")
+    def _compute_phones(self):
+        res = super(
+            HrEmployeeBase, self.filtered(lambda r: not r.work_phone)
+        )._compute_phones()
+        return res

--- a/cb_hr_views/models/hr_work_location.py
+++ b/cb_hr_views/models/hr_work_location.py
@@ -5,5 +5,6 @@ class HrWorkLocation(models.Model):
     _inherit = "hr.work.location"
 
     company_id = fields.Many2one(
-        "res.company", required=False, default=lambda self: self.env.company
+        "res.company",
+        required=False,
     )


### PR DESCRIPTION
If this field is empty work location can be selected in all employees despite of his company. But by default it is setted to envirnoment company, always Creu Blanca and all work locations can be selected only for Creu Blanca employees.

Creu Blanca set his work phone extensiones despite of addres_id so how his address hasn't setted a phone, every time address is modified, work_phone is setted to False.